### PR TITLE
Release chart v0.1.3 with controller v0.7.0

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,7 +24,7 @@ tasks:
       - curl -s https://raw.githubusercontent.com/kluctl/flux-kluctl-controller/{{.SOURCE_VER}}/config/crd/bases/flux.kluctl.io_kluctldeployments.yaml > charts/flux-kluctl-controller/crds/flux.kluctl.io_kluctldeployments.yaml
     vars:
       SOURCE_VER:
-        sh: "cat charts/flux-kluctl-controller/Chart.yaml | grep -Po '(?<=appVersion: )[^;]+' | tr -d '\"'"
+        sh: "cat charts/flux-kluctl-controller/Chart.yaml | grep '^appVersion:' | sed 's/appVersion: \"\\([^\"]*\\)\"/\\1/'"
   # Download RBAC
   download-all-rbac:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,9 @@
 version: '3'
 
+vars:
+  INPLACE_SED:
+    sh: 'if [ "$(uname)" = "Darwin" ]; then echo "sed -i \"\""; else echo "sed -i"; fi'
+
 tasks:
   # Meta Tasks for Charts
   prepare-all-releases:
@@ -33,8 +37,8 @@ tasks:
       - printf "$(curl -s https://raw.githubusercontent.com/kluctl/flux-kluctl-controller/{{.SOURCE_VER}}/config/rbac/kluctldeployment_editor_role.yaml)\n---\n" >> charts/flux-kluctl-controller/templates/clusterrole.yaml
       - printf "$(curl -s https://raw.githubusercontent.com/kluctl/flux-kluctl-controller/{{.SOURCE_VER}}/config/rbac/kluctldeployment_viewer_role.yaml)\n---\n" >> charts/flux-kluctl-controller/templates/clusterrole.yaml
       - printf "$(curl -s https://raw.githubusercontent.com/kluctl/flux-kluctl-controller/{{.SOURCE_VER}}/config/rbac/leader_election_role.yaml)\n---\n" > charts/flux-kluctl-controller/templates/role.yaml
-      - "sed -i -e 's/name: */name: {{.HELM_TEMPLATE_FULL_NAME}}-/' charts/flux-kluctl-controller/templates/clusterrole.yaml"
-      - "sed -i -e 's/name: */name: {{.HELM_TEMPLATE_FULL_NAME}}-/' charts/flux-kluctl-controller/templates/role.yaml"
+      - "{{.INPLACE_SED}} -e 's/name: */name: {{.HELM_TEMPLATE_FULL_NAME}}-/' charts/flux-kluctl-controller/templates/clusterrole.yaml"
+      - "{{.INPLACE_SED}} -e 's/name: */name: {{.HELM_TEMPLATE_FULL_NAME}}-/' charts/flux-kluctl-controller/templates/role.yaml"
     vars:
       SOURCE_VER:
         sh: "cat charts/flux-kluctl-controller/Chart.yaml | grep '^appVersion:' | sed 's/appVersion: \"\\([^\"]*\\)\"/\\1/'"
@@ -77,7 +81,7 @@ tasks:
   bump-chart-template:
     cmds:
       - git fetch --tags
-      - "sed -i \"s/^version: .*/version: $(docker run --rm -v \"${PWD}:/tmp\" -w /tmp convco/convco version --prefix \"{{.CHART_NAME}}-\" --bump -P charts/{{.CHART_NAME}})/\" charts/{{.CHART_NAME}}/Chart.yaml"
+      - '{{.INPLACE_SED}} "s/^version: .*/version: $(docker run --rm -v "${PWD}:/tmp" -w /tmp convco/convco version --prefix "{{.CHART_NAME}}-" --bump -P charts/{{.CHART_NAME}})/" charts/{{.CHART_NAME}}/Chart.yaml'
   # Create release commits for Charts
   create-all-release-commits:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,7 @@ tasks:
       - "sed -i -e 's/name: */name: {{.HELM_TEMPLATE_FULL_NAME}}-/' charts/flux-kluctl-controller/templates/role.yaml"
     vars:
       SOURCE_VER:
-        sh: "cat charts/flux-kluctl-controller/Chart.yaml | grep -Po '(?<=appVersion: )[^;]+' | tr -d '\"'"
+        sh: "cat charts/flux-kluctl-controller/Chart.yaml | grep '^appVersion:' | sed 's/appVersion: \"\\([^\"]*\\)\"/\\1/'"
       HELM_TEMPLATE_FULL_NAME: 'REPLACE_WITH_HELM_TEMPLATE'
   # Generate README.md files for Charts
   generate-all-readmes:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,7 @@ tasks:
     vars:
       SOURCE_VER:
         sh: "cat charts/flux-kluctl-controller/Chart.yaml | grep '^appVersion:' | sed 's/appVersion: \"\\([^\"]*\\)\"/\\1/'"
-      HELM_TEMPLATE_FULL_NAME: 'REPLACE_WITH_HELM_TEMPLATE'
+      HELM_TEMPLATE_FULL_NAME: '{{`{{ include "flux-kluctl-controller.fullname" . }}`}}'
   # Generate README.md files for Charts
   generate-all-readmes:
     cmds:

--- a/charts/flux-kluctl-controller/CHANGELOG.md
+++ b/charts/flux-kluctl-controller/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
-## [Unreleased](https://github.com/kluctl/charts/compare/flux-kluctl-controller-0.1.1...HEAD) (2022-09-23)
+## [Unreleased](https://github.com/kluctl/charts/compare/flux-kluctl-controller-0.1.2...HEAD) (2022-09-28)
 
 ### Features
+
+* Upgrade CRDs
+  ([b621345](https://github.com/kluctl/charts/commit/b621345a1c096d1e39eb7bc90d4fbca1c758fadb))
+* Manually bump versions
+  ([21d5b3d](https://github.com/kluctl/charts/commit/21d5b3deb45d7daf03d26f9230405cff601c1fb9))
+
+### [flux-kluctl-controller-0.1.2](https://github.com/kluctl/charts/compare/flux-kluctl-controller-0.1.1...flux-kluctl-controller-0.1.2) (2022-09-23)
+
+#### Features
 
 * **flux-kluctl-controller:** update appVersion to v0.6.3
   ([3ae9314](https://github.com/kluctl/charts/commit/3ae9314d0f76099344ea960dfaf19da454691186))

--- a/charts/flux-kluctl-controller/Chart.yaml
+++ b/charts/flux-kluctl-controller/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
     name: codablock
 description: A Helm chart for the flux-kluctl-controller
 type: application
-version: 0.1.2
-appVersion: "v0.6.3"
+version: 0.1.3
+appVersion: "v0.7.0"

--- a/charts/flux-kluctl-controller/README.md
+++ b/charts/flux-kluctl-controller/README.md
@@ -1,6 +1,6 @@
 # flux-kluctl-controller
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.6.3](https://img.shields.io/badge/AppVersion-v0.6.3-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.7.0](https://img.shields.io/badge/AppVersion-v0.7.0-informational?style=flat-square)
 
 A Helm chart for the flux-kluctl-controller
 
@@ -36,12 +36,9 @@ A Helm chart for the flux-kluctl-controller
 | service.health.port | int | `9440` |  |
 | service.prometheus.port | int | `8080` |  |
 | service.type | string | `"ClusterIP"` |  |
-| serviceAccount.controller.annotations | object | `{}` |  |
-| serviceAccount.controller.create | bool | `true` |  |
-| serviceAccount.controller.prefix | string | `""` |  |
-| serviceAccount.reconciler.annotations | object | `{}` |  |
-| serviceAccount.reconciler.create | bool | `true` |  |
-| serviceAccount.reconciler.prefix | string | `""` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
 | tolerations | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/flux-kluctl-controller/crds/flux.kluctl.io_kluctldeployments.yaml
+++ b/charts/flux-kluctl-controller/crds/flux.kluctl.io_kluctldeployments.yaml
@@ -62,15 +62,15 @@ spec:
                   when calling kluctl.
                 type: boolean
               args:
-                additionalProperties:
-                  type: string
                 description: Args specifies dynamic target args. Only arguments defined
                   by 'dynamicArgs' of the target are allowed.
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               deployInterval:
                 description: DeployInterval specifies the interval at which to deploy
-                  the KluctlDeployment. This is independent of the 'Interval' value,
-                  which only causes deployments if some deployment objects have changed.
+                  the KluctlDeployment. It defaults to the Interval value, meaning
+                  that it will re-deploy on every reconciliation. If you set DeployInterval
+                  to a different value,
                 type: string
               deployMode:
                 default: full-deploy
@@ -79,6 +79,14 @@ spec:
                 - full-deploy
                 - poke-images
                 type: string
+              deployOnChanges:
+                default: true
+                description: DeployOnChanges will cause a re-deployment whenever the
+                  rendered resources change in the deployment. This check is performed
+                  on every reconciliation. This means that a deployment will be triggered
+                  even before the DeployInterval has passed in case something has
+                  changed in the rendered resources.
+                type: boolean
               dryRun:
                 default: false
                 description: DryRun instructs kluctl to run everything in dry-run
@@ -178,6 +186,9 @@ spec:
                 type: array
               interval:
                 description: The interval at which to reconcile the KluctlDeployment.
+                  By default, the controller will re-deploy and validate the deployment
+                  on each reconciliation. To override this behavior, change the DeployInterval
+                  and/or ValidateInterval values.
                 type: string
               kubeConfig:
                 description: The KubeConfig for deploying to the target cluster. Specifies
@@ -266,8 +277,8 @@ spec:
                 type: boolean
               retryInterval:
                 description: The interval at which to retry a previously failed reconciliation.
-                  When not specified, the controller uses the KluctlDeploymentSpec.Interval
-                  value to retry failures.
+                  When not specified, the controller uses the Interval value to retry
+                  failures.
                 type: string
               serviceAccountName:
                 description: The name of the Kubernetes service account to use while
@@ -315,11 +326,16 @@ spec:
                 description: UpdateImages instructs kluctl to update dynamic images.
                   Equivalent to using '-u' when calling kluctl.
                 type: boolean
+              validate:
+                default: true
+                description: Validate enables validation after deploying
+                type: boolean
               validateInterval:
-                default: 5m
                 description: ValidateInterval specifies the interval at which to validate
                   the KluctlDeployment. Validation is performed the same way as with
-                  'kluctl validate -t <target>'. Defaults to 1m.
+                  'kluctl validate -t <target>'. Defaults to the same value as specified
+                  in Interval. Validate is also performed whenever a deployment is
+                  performed, independent of the value of ValidateInterval
                 type: string
             required:
             - interval

--- a/charts/flux-kluctl-controller/templates/_helpers.tpl
+++ b/charts/flux-kluctl-controller/templates/_helpers.tpl
@@ -52,23 +52,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Create the name of the service account to use for the controller
+Create the name of the service account to use
 */}}
-{{- define "flux-kluctl-controller.serviceAccountNameController" -}}
-{{- if .Values.serviceAccount.controller.create }}
-{{- default (include "flux-kluctl-controller.fullname" .) .Values.serviceAccount.controller.prefix }}-controller
+{{- define "flux-kluctl-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "flux-kluctl-controller.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.controller.prefix }}
-{{- end }}
-{{- end }}
-
-{{/*
-Create the name of the service account to use for the reconciler
-*/}}
-{{- define "flux-kluctl-controller.serviceAccountNameReconciler" -}}
-{{- if .Values.serviceAccount.reconciler.create }}
-{{- default (include "flux-kluctl-controller.fullname" .) .Values.serviceAccount.reconciler.prefix }}-reconciler
-{{- else }}
-{{- default "default" .Values.serviceAccount.reconciler.prefix }}-reconciler
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/charts/flux-kluctl-controller/templates/clusterrolebinding.yaml
+++ b/charts/flux-kluctl-controller/templates/clusterrolebinding.yaml
@@ -8,7 +8,7 @@ roleRef:
   name: {{ include "flux-kluctl-controller.fullname" . }}-manager-role
 subjects:
   - kind: ServiceAccount
-    name: {{ include "flux-kluctl-controller.serviceAccountNameController" . }}
+    name: {{ include "flux-kluctl-controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -21,7 +21,7 @@ roleRef:
   name: {{ include "flux-kluctl-controller.fullname" . }}-kluctldeployment-editor-role
 subjects:
   - kind: ServiceAccount
-    name: {{ include "flux-kluctl-controller.serviceAccountNameController" . }}
+    name: {{ include "flux-kluctl-controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,7 +34,7 @@ roleRef:
   name: {{ include "flux-kluctl-controller.fullname" . }}-kluctldeployment-viewer-role
 subjects:
   - kind: ServiceAccount
-    name: {{ include "flux-kluctl-controller.serviceAccountNameController" . }}
+    name: {{ include "flux-kluctl-controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -47,5 +47,5 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: {{ include "flux-kluctl-controller.serviceAccountNameReconciler" . }}
+    name: {{ include "flux-kluctl-controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/flux-kluctl-controller/templates/deployment.yaml
+++ b/charts/flux-kluctl-controller/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "flux-kluctl-controller.serviceAccountNameController" . }}
+      serviceAccountName: {{ include "flux-kluctl-controller.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -49,7 +49,6 @@ spec:
             - --log-level=info
             - --log-encoding=json
             - --enable-leader-election
-            - --default-service-account={{ include "flux-kluctl-controller.serviceAccountNameReconciler" . }}
           readinessProbe:
             httpGet:
               path: /readyz

--- a/charts/flux-kluctl-controller/templates/rolebinding.yaml
+++ b/charts/flux-kluctl-controller/templates/rolebinding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: {{ include "flux-kluctl-controller.fullname" . }}-leader-election-role
 subjects:
   - kind: ServiceAccount
-    name: {{ include "flux-kluctl-controller.serviceAccountNameController" . }}
+    name: {{ include "flux-kluctl-controller.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/flux-kluctl-controller/templates/serviceaccount.yaml
+++ b/charts/flux-kluctl-controller/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.controller.create -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/flux-kluctl-controller/templates/serviceaccount.yaml
+++ b/charts/flux-kluctl-controller/templates/serviceaccount.yaml
@@ -2,23 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "flux-kluctl-controller.serviceAccountNameController" . }}
+  name: {{ include "flux-kluctl-controller.serviceAccountName" . }}
   labels:
     {{- include "flux-kluctl-controller.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.controller.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-{{- end }}
----
-{{- if .Values.serviceAccount.reconciler.create }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ include "flux-kluctl-controller.serviceAccountNameReconciler" . }}
-  labels:
-    {{- include "flux-kluctl-controller.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.reconciler.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/flux-kluctl-controller/values.yaml
+++ b/charts/flux-kluctl-controller/values.yaml
@@ -13,22 +13,13 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
-  controller:
-    # Specifies whether a service account should be created
-    create: true
-    # Annotations to add to the service account
-    annotations: {}
-    # The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template
-    prefix: ""
-  reconciler:
-    # Specifies whether a service account should be created
-    create: true
-    # Annotations to add to the service account
-    annotations: {}
-    # The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template
-    prefix: ""
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
 
 podAnnotations:
   prometheus.io/scrape: "true"


### PR DESCRIPTION
This PR also reverts the support for two different service accounts (controller+reconciler) as it turned out that we had a misunderstanding of the flux `--default-service-account` flag.