### PR TITLE
feat: Allow users to specify additional env variables

### DIFF
--- a/charts/flux-kluctl-controller/templates/deployment.yaml
+++ b/charts/flux-kluctl-controller/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           args:
             - --watch-all-namespaces
             - --log-level=info

--- a/charts/flux-kluctl-controller/values.yaml
+++ b/charts/flux-kluctl-controller/values.yaml
@@ -38,6 +38,13 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# Additional environment variables
+env: []
+  # - name: HTTPS_PROXY
+  #   value: https://proxy.example.org
+  # - name: NO_PROXY
+  #   value: 10.96.0.1
+
 service:
   type: ClusterIP
   prometheus:

--- a/charts/template-controller/templates/deployment.yaml
+++ b/charts/template-controller/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- with .Values.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           args:
             - --watch-all-namespaces
             - --leader-elect

--- a/charts/template-controller/values.yaml
+++ b/charts/template-controller/values.yaml
@@ -38,6 +38,13 @@ securityContext:
   seccompProfile:
     type: RuntimeDefault
 
+# Additional environment variables
+env: []
+  # - name: HTTPS_PROXY
+  #   value: https://proxy.example.org
+  # - name: NO_PROXY
+  #   value: 10.96.0.1
+
 service:
   type: ClusterIP
   prometheus:


### PR DESCRIPTION
# Description
With the controllers now pulling from external sources directly (instead of through the Flux repo server), they may need a proxy configuration in some cases, which can be added via `HTTP(S)_PROXY` environment variables.
This PR adds the ability for users to specify additional environment variables that are then included in the deployments.

I have also bumped the version of the charts by 0.0.1.
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

<!---
All Submissions:

* [ ] A corresponding issue exists
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [x] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
