### PR TITLE
feat(template-controller): aggregated user-facing cluster roles for all custom resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea/
 package/
+*.iml

--- a/charts/template-controller/templates/clusterrole.yaml
+++ b/charts/template-controller/templates/clusterrole.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: {{ include "template-controller.fullname" . }}-manager-role
 rules:
 - apiGroups:
@@ -255,275 +254,80 @@ rules:
   - patch
   - update
 ---
-# permissions for end users to edit gitprojectors.
+# permissions for end users to view template-controller resources.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: {{ include "template-controller.fullname" . }}-viewer-role
   labels:
-    app.kubernetes.io/name: {{ include "template-controller.fullname" . }}-clusterrole
-    app.kubernetes.io/instance: gitprojector-editor-role
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: template-controller
-    app.kubernetes.io/part-of: template-controller
-    app.kubernetes.io/managed-by: kustomize
-  name: {{ include "template-controller.fullname" . }}-gitprojector-editor-role
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
 - apiGroups:
   - templates.kluctl.io
   resources:
+  - githubcomments
+  - gitlabcomments
   - gitprojectors
+  - listgithubpullrequests
+  - listgitlabmergerequests
+  - objecthandlers
+  - objecttemplates
+  - texttemplates
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
   - watch
 - apiGroups:
   - templates.kluctl.io
   resources:
+  - githubcomments/status
+  - gitlabcomments/status
   - gitprojectors/status
+  - listgithubpullrequests/status
+  - listgitlabmergerequests/status
+  - objecthandlers/status
+  - objecttemplates/status
+  - texttemplates/status
   verbs:
   - get
 ---
-# permissions for end users to view gitprojectors.
+# permissions for end users to edit template-controller resources.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: {{ include "template-controller.fullname" . }}-editor-role
   labels:
-    app.kubernetes.io/name: {{ include "template-controller.fullname" . }}-clusterrole
-    app.kubernetes.io/instance: gitprojector-viewer-role
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: template-controller
-    app.kubernetes.io/part-of: template-controller
-    app.kubernetes.io/managed-by: kustomize
-  name: {{ include "template-controller.fullname" . }}-gitprojector-viewer-role
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
 - apiGroups:
   - templates.kluctl.io
   resources:
+  - githubcomments
+  - gitlabcomments
   - gitprojectors
+  - listgithubpullrequests
+  - listgitlabmergerequests
+  - objecthandlers
+  - objecttemplates
+  - texttemplates
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - templates.kluctl.io
   resources:
+  - githubcomments/status
+  - gitlabcomments/status
   - gitprojectors/status
-  verbs:
-  - get
----
-# permissions for end users to edit listgithubpullrequests.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "template-controller.fullname" . }}-clusterrole
-    app.kubernetes.io/instance: listgithubpullrequests-editor-role
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: template-controller
-    app.kubernetes.io/part-of: template-controller
-    app.kubernetes.io/managed-by: kustomize
-  name: {{ include "template-controller.fullname" . }}-listgithubpullrequests-editor-role
-rules:
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - listgithubpullrequests
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - templates.kluctl.io
-  resources:
   - listgithubpullrequests/status
-  verbs:
-  - get
----
-# permissions for end users to view listgithubpullrequests.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "template-controller.fullname" . }}-clusterrole
-    app.kubernetes.io/instance: listgithubpullrequests-viewer-role
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: template-controller
-    app.kubernetes.io/part-of: template-controller
-    app.kubernetes.io/managed-by: kustomize
-  name: {{ include "template-controller.fullname" . }}-listgithubpullrequests-viewer-role
-rules:
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - listgithubpullrequests
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - listgithubpullrequests/status
-  verbs:
-  - get
----
-# permissions for end users to edit listgitlabmergerequests.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "template-controller.fullname" . }}-clusterrole
-    app.kubernetes.io/instance: listgitlabmergerequests-editor-role
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: template-controller
-    app.kubernetes.io/part-of: template-controller
-    app.kubernetes.io/managed-by: kustomize
-  name: {{ include "template-controller.fullname" . }}-listgitlabmergerequests-editor-role
-rules:
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - listgitlabmergerequests
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - templates.kluctl.io
-  resources:
   - listgitlabmergerequests/status
-  verbs:
-  - get
----
-# permissions for end users to view listgitlabmergerequests.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/name: {{ include "template-controller.fullname" . }}-clusterrole
-    app.kubernetes.io/instance: listgitlabmergerequests-viewer-role
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: template-controller
-    app.kubernetes.io/part-of: template-controller
-    app.kubernetes.io/managed-by: kustomize
-  name: {{ include "template-controller.fullname" . }}-listgitlabmergerequests-viewer-role
-rules:
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - listgitlabmergerequests
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - listgitlabmergerequests/status
-  verbs:
-  - get
----
-# permissions for end users to edit objecthandlers.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "template-controller.fullname" . }}-objecthandler-editor-role
-rules:
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - objecthandlers
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - templates.kluctl.io
-  resources:
   - objecthandlers/status
-  verbs:
-  - get
----
-# permissions for end users to view objecthandlers.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "template-controller.fullname" . }}-objecthandler-viewer-role
-rules:
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - objecthandlers
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - objecthandlers/status
-  verbs:
-  - get
----
-# permissions for end users to edit objecttemplates.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "template-controller.fullname" . }}-objecttemplate-editor-role
-rules:
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - objecttemplates
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - templates.kluctl.io
-  resources:
   - objecttemplates/status
+  - texttemplates/status
   verbs:
   - get
----
-# permissions for end users to view objecttemplates.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "template-controller.fullname" . }}-objecttemplate-viewer-role
-rules:
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - objecttemplates
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - templates.kluctl.io
-  resources:
-  - objecttemplates/status
-  verbs:
-  - get
----


### PR DESCRIPTION
# Description

While trying to install template-controller, I noticed that user-facing RBAC to some custom resources was missing. In addition, the cluster roles are lacking the labels making them aggregate rules to the [default Kubernetes user-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!---
All Submissions:

* [ ] A corresponding issue exists
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [ ] I have performed a self-review of my code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] Have you lint your code locally before submission?
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged and published in downstream modules
* [ ] All commits are signed off which certify that you created the patch and that you agree to the [Developer Certificate of Origin](https://developercertificate.org/)
-->
